### PR TITLE
feat: add results table to CNV report

### DIFF
--- a/config/cnv_report_template.html
+++ b/config/cnv_report_template.html
@@ -36,6 +36,10 @@
             text-align: right;
         }
 
+        .view-region-link {
+            cursor: pointer;
+        }
+
         .panel-overlay {
             stroke-width: 0;
         }
@@ -398,7 +402,7 @@
                 data = plotData;
                 xScale.domain([0, data.length]);
                 if (xMin && xMax) {
-                    xScale.domain([xMin, xMax]);
+                    xScale.domain([Math.max(xMin, 0), Math.min(xMax, data.length)]);
                 }
                 yScale.domain(d3.extent(data[`${activeDataset}_ratios`], d => d.log2));
                 svg.transition().select(".x-axis")
@@ -721,6 +725,12 @@
                             }
                         };
 
+                    case "view":
+                        return {
+                            class: "view-region-link",
+                            format: x => x,
+                        };
+
                     // Strings
                     case "caller":
                     case "chromosome":
@@ -730,7 +740,7 @@
                         return {
                             class: "left",
                             format: x => x,
-                        }
+                        };
                 }
             }
 
@@ -739,7 +749,7 @@
                     .map(d => d["cnvs"]
                         .filter(v => v.caller == dataset)
                         .map(di => {
-                            const allCols = {chromosome: d.chromosome, ...di};
+                            const allCols = {view: "🔍", chromosome: d.chromosome, ...di};
                             const {caller, ...cols} = allCols;
                             return cols;
                         }))
@@ -759,15 +769,21 @@
                         .attr("data-chromosome", d => d.chromosome)
                         .attr("data-start", d => d.start)
                         .attr("data-length", d => d.length)
-                        .on("click", e => {
-                            const dataset = e.target.parentElement.dataset;
-                            console.log(`${dataset.chromosome}:${dataset.start}`);
-                        })
                         .selectAll("td")
                         .data(d => Object.entries(d))
                         .join("td")
                             .text(([key, value]) => getColumnDef(key).format(value))
                             .attr("class", ([key, value]) => getColumnDef(key).class);
+
+                tableBody.selectAll(".view-region-link")
+                    .on("click", e => {
+                        const dataset = e.target.parentElement.dataset;
+                        zoomToRegion(
+                            dataset.chromosome,
+                            Number(dataset.start),
+                            Number(dataset.start) + Number(dataset.length)
+                        );
+                    });
             }
 
             const getData = () => tableData;
@@ -779,6 +795,17 @@
                 update: update,
             };
         };
+
+        const zoomToRegion = (chromosome, start, end, padding = 0.05) => {
+            genomeView.selectChromosome(chromosome)
+            let bpPadding = (end - start) * padding;
+            chromosomeView.update(
+                cnvData[genomeView.getSelectedChromosome()],
+                activeDataset,
+                start - bpPadding,
+                end + bpPadding
+            );
+        }
 
         let activeDataset = getActiveDataset();
 

--- a/config/cnv_report_template.html
+++ b/config/cnv_report_template.html
@@ -14,9 +14,41 @@
             border-collapse: collapse;
         }
 
+        th, td {
+            padding: 0.6rem 0.5rem 0.1rem 0.5rem;
+        }
+
         th {
             border-bottom: 1px solid #333;
             text-align: left;
+        }
+
+        th:nth-child(1) {
+            width: 5%;
+        }
+
+        th:nth-child(2) {
+            width: 15%;
+        }
+
+        th:nth-child(3) {
+            width: 15%;
+        }
+
+        th:nth-child(4) {
+            width: 15%;
+        }
+
+        th:nth-child(5) {
+            width: 20%;
+        }
+
+        th:nth-child(6) {
+            width: 20%;
+        }
+
+        th:nth-child(7) {
+            width: 10%;
         }
 
         thead {

--- a/config/cnv_report_template.html
+++ b/config/cnv_report_template.html
@@ -186,14 +186,16 @@
                             .attr("r", 2)
                             .attr("fill", "#333")
                             .attr("fill-opacity", 0)
-                            .transition()
-                            .duration(500)
-                            .attr("fill-opacity", 0.3),
+                            .call(enter => enter.transition()
+                                .duration(500)
+                                .attr("fill-opacity", 0.3)
+                            ),
                         update => update
-                            .transition()
-                            .attr("cx", d => xScale(d.start)),
-                        exit => exit
-                            .transition()
+                            .attr("fill-opacity", 0.3)
+                            .call(update => update.transition()
+                                .attr("cx", d => xScale(d.start))
+                            ),
+                        exit => exit.transition()
                             .attr("fill-opacity", 0)
                             .remove()
                     );
@@ -211,15 +213,16 @@
                             .attr("stroke", "orange")
                             .attr("stroke-width", 2)
                             .attr("stroke-opacity", 0)
-                            .transition()
-                            .duration(500)
-                            .attr("stroke-opacity", 1),
+                            .call(enter => enter.transition()
+                                .attr("stroke-opacity", 1)
+                            ),
                         update => update
-                            .transition()
-                            .attr("d", d =>
-                                `M${xScale(d.start)} ${yScale(d.log2)} L ${xScale(d.end)} ${yScale(d.log2)}`),
-                        exit => exit
-                            .transition()
+                            .attr("stroke-opacity", 1)
+                            .call(update => update.transition()
+                                .attr("d", d =>
+                                    `M${xScale(d.start)} ${yScale(d.log2)} L ${xScale(d.end)} ${yScale(d.log2)}`)
+                            ),
+                        exit => exit.transition()
                             .attr("stroke-opacity", 0)
                             .remove()
                     );
@@ -237,12 +240,14 @@
                                 .attr("x", d => xScale(d.start))
                                 .attr("width", d => xScale(d.end - d.start))
                                 .attr("height", height - margin.top - margin.bottom)
-                                .transition()
-                                .attr("fill", "#333")
-                                .attr("fill-opacity", 0.05)
                                 .attr("stroke", "#000")
                                 .attr("stroke-width", 0.5)
-                                .attr("pointer-events", "none");
+                                .attr("fill", "#333")
+                                .attr("fill-opacity", 0)
+                                .attr("pointer-events", "none")
+                                .call(enter => enter.transition()
+                                    .attr("fill-opacity", 0.05)
+                                );
                             gene_group.append("rect")
                                 .attr("class", "gene-label-background")
                                 .attr("x", d => {
@@ -268,21 +273,24 @@
                             return gene_group;
                         }, update => {
                             update.selectAll(".gene-label")
-                                .transition()
-                                .attr("x", d => xScale(d.start + (d.end - d.start) / 2));
+                                .call(update => update.transition()
+                                    .attr("x", d => xScale(d.start + (d.end - d.start) / 2))
+                                );
                             update.selectAll(".gene-label-background")
-                                .transition()
-                                .attr("x", d => {
-                                    let [labelWidth, labelHeight] = getTextDimensions(d.gene, "0.8rem");
-                                    return xScale(d.start + (d.end - d.start) / 2) - labelWidth / 2 - 5;
-                                });
+                                .call(update => update.transition()
+                                    .attr("x", d => {
+                                        let [labelWidth, labelHeight] = getTextDimensions(d.gene, "0.8rem");
+                                        return xScale(d.start + (d.end - d.start) / 2) - labelWidth / 2 - 5;
+                                    })
+                                );
                             update.selectAll(".gene-marker")
-                                .transition()
-                                .attr("x", d => xScale(d.start))
-                                .attr("width", d => xScale(d.end) - xScale(d.start));
+                                .attr("fill-opacity", 0.05)
+                                .call(update => update.transition()
+                                    .attr("x", d => xScale(d.start))
+                                    .attr("width", d => xScale(d.end) - xScale(d.start))
+                                );
                             return update;
-                        }, exit => exit
-                            .transition()
+                        }, exit => exit.transition()
                             .attr("fill-opacity", 0)
                             .attr("stroke-opacity", 0)
                             .remove()

--- a/config/cnv_report_template.html
+++ b/config/cnv_report_template.html
@@ -1,10 +1,41 @@
 <!DOCTYPE html>
+
 <html lang="en">
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=1080, initial-scale=1.0">
     <title>CNV report</title>
+
+    <style>
+        table {
+            table-layout: fixed;
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        th {
+            border-bottom: 1px solid #333;
+            text-align: left;
+        }
+
+        thead {
+            background-color: #DDD;
+            border-bottom: 1px solid #333;
+        }
+
+        tbody tr:nth-child(2n) {
+            background-color: #F5F5F5;
+        }
+
+        .left {
+            text-align: left;
+        }
+
+        .right {
+            text-align: right;
+        }
+    </style>
 </head>
 <body>
     <h1>CNV report</h1>
@@ -33,6 +64,13 @@
         <h2>Chromosome view</h2>
         <p>Click and drag to zoom. Click the plot to reset zoom.</p>
         <svg id="chromosome-view"></svg>
+    </section>
+
+    <section>
+        <h2>Results table</h2>
+        <table id="cnv-table">
+
+        </table>
     </section>
 
     <script src="https://d3js.org/d3.v7.min.js"></script>
@@ -639,16 +677,78 @@
             };
         };
 
+        const populateTable = (dataset) => {
+            const table = d3.select("#cnv-table");
+
+            const tableHeader = table.append("thead").append("tr");
+            const tableBody = table.append("tbody");
+
+            let tableData = null;
+
+            const getAlignment = col => {
+                switch (col) {
+                    case "chromosome":
+                    case "genes":
+                        return "left";
+
+                    default:
+                        return "right";
+                }
+            }
+
+            const update = dataset => {
+                tableData = cnvData
+                    .map(d => d[`${dataset}_segments`]
+                        .map(di => {return {chromosome: d.chromosome, ...di}}))
+                    .flat();
+
+                tableHeader
+                    .selectAll("th")
+                    .data(Object.keys(tableData[0]), d => d)
+                    .join("th")
+                        .text(d => d)
+                        .attr("class", getAlignment);
+
+                tableBody
+                    .selectAll("tr")
+                    .data(tableData)
+                    .join("tr")
+                        .attr("data-chromosome", d => d.chromosome)
+                        .attr("data-start", d => d.start)
+                        .attr("data-end", d => d.end)
+                        .on("click", e => {
+                            const dataset = e.target.parentElement.dataset;
+                            console.log(`${dataset.chromosome}:${dataset.start}-${dataset.end}`);
+                        })
+                        .selectAll("td")
+                        .data(d => Object.entries(d))
+                        .join("td")
+                            .text(([key, value]) => value)
+                            .attr("class", ([key, value]) => getAlignment(key));
+            }
+
+            const getData = () => tableData;
+
+            update(dataset);
+
+            return {
+                getData: getData,
+                update: update,
+            };
+        };
+
         let activeDataset = getActiveDataset();
 
         const chromosomeView = plotChromosomeView(cnvData[0], activeDataset);
         const genomeView = plotGenomeView(activeDataset);
+        const resultsTable = populateTable(activeDataset);
 
         d3.selectAll("input[name=dataset]").on("change", e => {
             activeDataset = e.target.value;
             let [xMin, xMax] = chromosomeView.getZoomRange();
             chromosomeView.update(cnvData[genomeView.getSelectedChromosome()], activeDataset, xMin, xMax);
             genomeView.update(activeDataset);
+            resultsTable.update(activeDataset);
         });
 
     </script>

--- a/config/cnv_report_template.html
+++ b/config/cnv_report_template.html
@@ -685,21 +685,56 @@
 
             let tableData = null;
 
-            const getAlignment = col => {
+            const getColumnDef = col => {
                 switch (col) {
-                    case "chromosome":
-                    case "genes":
-                        return "left";
+                    // Integers
+                    case "start":
+                    case "length":
+                    case "end":
+                        return {
+                            class: "right",
+                            format: x => x.toLocaleString(undefined, {}),
+                        };
 
+                    // Floating point, allow for missing numbers
+                    case "copyNumber":
+                    case "corrCopyNumber":
+                    case "cn":
+                        return {
+                            class: "right",
+                            format: x => {
+                                if (x) {
+                                    return x.toLocaleString(
+                                        undefined,
+                                        { minimumFractionDigits: 2 }
+                                    );
+                                }
+                                return "NA";
+                            }
+                        };
+
+                    // Strings
+                    case "caller":
+                    case "chromosome":
+                    case "gene":
+                    case "type":
                     default:
-                        return "right";
+                        return {
+                            class: "left",
+                            format: x => x,
+                        }
                 }
             }
 
             const update = dataset => {
                 tableData = cnvData
-                    .map(d => d[`${dataset}_segments`]
-                        .map(di => {return {chromosome: d.chromosome, ...di}}))
+                    .map(d => d["cnvs"]
+                        .filter(v => v.caller == dataset)
+                        .map(di => {
+                            const allCols = {chromosome: d.chromosome, ...di};
+                            const {caller, ...cols} = allCols;
+                            return cols;
+                        }))
                     .flat();
 
                 tableHeader
@@ -707,7 +742,7 @@
                     .data(Object.keys(tableData[0]), d => d)
                     .join("th")
                         .text(d => d)
-                        .attr("class", getAlignment);
+                        .attr("class", d => getColumnDef(d).class);
 
                 tableBody
                     .selectAll("tr")
@@ -715,16 +750,16 @@
                     .join("tr")
                         .attr("data-chromosome", d => d.chromosome)
                         .attr("data-start", d => d.start)
-                        .attr("data-end", d => d.end)
+                        .attr("data-length", d => d.length)
                         .on("click", e => {
                             const dataset = e.target.parentElement.dataset;
-                            console.log(`${dataset.chromosome}:${dataset.start}-${dataset.end}`);
+                            console.log(`${dataset.chromosome}:${dataset.start}`);
                         })
                         .selectAll("td")
                         .data(d => Object.entries(d))
                         .join("td")
-                            .text(([key, value]) => value)
-                            .attr("class", ([key, value]) => getAlignment(key));
+                            .text(([key, value]) => getColumnDef(key).format(value))
+                            .attr("class", ([key, value]) => getColumnDef(key).class);
             }
 
             const getData = () => tableData;

--- a/config/cnv_report_template.html
+++ b/config/cnv_report_template.html
@@ -270,7 +270,7 @@
                             gene_group.append("rect")
                                 .attr("class", "gene-marker")
                                 .attr("x", d => xScale(d.start))
-                                .attr("width", d => xScale(d.end - d.start))
+                                .attr("width", d => xScale(d.end) - xScale(d.start))
                                 .attr("height", height - margin.top - margin.bottom)
                                 .attr("stroke", "#000")
                                 .attr("stroke-width", 0.5)

--- a/config/cnv_report_template.html
+++ b/config/cnv_report_template.html
@@ -8,6 +8,10 @@
     <title>CNV report</title>
 
     <style>
+        body {
+            font-family: helvetica, arial, sans-serif;
+        }
+
         table {
             table-layout: fixed;
             width: 100%;

--- a/config/cnv_report_template.html
+++ b/config/cnv_report_template.html
@@ -35,6 +35,14 @@
         .right {
             text-align: right;
         }
+
+        .panel-overlay {
+            stroke-width: 0;
+        }
+
+        .panel-overlay.selected {
+            stroke-width: 6;
+        }
     </style>
 </head>
 <body>
@@ -596,11 +604,20 @@
                     .attr("height", panelHeight);
 
             let selectedChromosomeIndex = 0;
+            const selectChromosome = chromosome => {
+                selectedChromosomeIndex = cnvData.findIndex(d => d.chromosome === chromosome);
+                plotArea.selectAll(".panel-overlay")
+                    .classed("selected", false);
+                plotArea.selectAll(`.panel-${selectedChromosomeIndex}-overlay`)
+                    .classed("selected", true);
+                chromosomeView.update(cnvData[selectedChromosomeIndex], activeDataset);
+            }
+
             const overlays = d3.selectAll(".genome-view-area").append("g");
             overlays.selectAll(".panel-overlay")
                 .data(panelWidths)
                 .join("rect")
-                    .attr("class", (d, i) => `panel-overlay panel-${i}-overlay`)
+                    .attr("class", (d, i) => `panel-overlay panel-${i}-overlay${i === 0 ? " selected" : ""}`)
                     .attr("transform", (d, i) => `translate(${i === 0 ? 0 : d3.sum(panelWidths.slice(0, i))}, 0)`)
                     .attr("data-index", (d, i) => i)
                     .attr("width", d => d)
@@ -609,7 +626,6 @@
                     .attr("fill", "#000")
                     .attr("fill-opacity", 0)
                     .attr("stroke", "forestgreen")
-                    .attr("stroke-width", (d, i) => i === 0 ? 6 : 0)
                     .on("mouseenter", e => {
                         plotArea.selectAll(".panel-overlay")
                             .attr("fill-opacity", 0);
@@ -620,16 +636,7 @@
                         d3.selectAll(`.panel-${e.target.dataset.index}-overlay`)
                             .attr("fill-opacity", 0);
                     })
-                    .on("click", (e, d, i) => {
-                        selectedChromosomeIndex = e.target.dataset.index;
-                        chromosomeView.update(cnvData[selectedChromosomeIndex], getActiveDataset());
-                        plotArea.selectAll(".panel-overlay")
-                            .classed("selected", false)
-                            .attr("stroke-width", 0);
-                        d3.selectAll(`.panel-${e.target.dataset.index}-overlay`)
-                            .classed("selected", true)
-                            .attr("stroke-width", 6);
-                    });
+                    .on("click", (e, d, i) => selectChromosome(cnvData[e.target.dataset.index].chromosome));
 
             // Y axes
             svg.append("g")
@@ -674,6 +681,7 @@
             return {
                 update: update,
                 getSelectedChromosome: getSelectedChromosome,
+                selectChromosome: selectChromosome,
             };
         };
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ jinja2==3.0.1
 networkx
 drmaa
 cyvcf2==0.30.16
+tabulate<0.9.0

--- a/workflow/rules/cnv_html_report.smk
+++ b/workflow/rules/cnv_html_report.smk
@@ -9,12 +9,12 @@ rule cnv_json:
         fai=config.get("reference").get("fai"),
         loh_bed=config.get("annotate_cnv", {}).get("cnv_loh_genes", []),
         svdb_vcfs=[
-            "cnv_sv/svdb_query/{sample}_{type}.svdb_query.annotate_cnv.cnv_amp_genes.vcf.gz",
-            "cnv_sv/svdb_query/{sample}_{type}.svdb_query.annotate_cnv.cnv_loh_genes.vcf.gz",
+            "cnv_sv/svdb_query/{sample}_{type}.svdb_query.annotate_cnv.cnv_amp_genes.filter.cnv_hard_filter_amp.vcf.gz",
+            "cnv_sv/svdb_query/{sample}_{type}.svdb_query.annotate_cnv.cnv_loh_genes.filter.cnv_hard_filter_loh.vcf.gz",
         ],
         svdb_tbis=[
-            "cnv_sv/svdb_query/{sample}_{type}.svdb_query.annotate_cnv.cnv_amp_genes.vcf.gz.tbi",
-            "cnv_sv/svdb_query/{sample}_{type}.svdb_query.annotate_cnv.cnv_loh_genes.vcf.gz.tbi",
+            "cnv_sv/svdb_query/{sample}_{type}.svdb_query.annotate_cnv.cnv_amp_genes.filter.cnv_hard_filter_amp.vcf.gz.tbi",
+            "cnv_sv/svdb_query/{sample}_{type}.svdb_query.annotate_cnv.cnv_loh_genes.filter.cnv_hard_filter_loh.vcf.gz.tbi",
         ],
     output:
         json=temp("cnv_sv/cnv_html_report/{sample}_{type}.cnv.json"),

--- a/workflow/rules/cnv_html_report.smk
+++ b/workflow/rules/cnv_html_report.smk
@@ -5,9 +5,17 @@ rule cnv_json:
         cns="cnv_sv/cnvkit_batch/{sample}/{sample}_{type}.cns",
         gatk_ratios="cnv_sv/gatk_cnv_denoise_read_counts/{sample}_{type}.clean.denoisedCR.tsv",
         gatk_segments="cnv_sv/gatk_cnv_model_segments/{sample}_{type}.clean.cr.seg",
+        germline_vcf="snv_indels/bcbio_variation_recall_ensemble/{sample}_{type}.ensembled.vep_annotated.filter.germline.vcf",
         fai=config.get("reference").get("fai"),
         loh_bed=config.get("annotate_cnv", {}).get("cnv_loh_genes", []),
-        vcf="snv_indels/bcbio_variation_recall_ensemble/{sample}_{type}.ensembled.vep_annotated.filter.germline.vcf",
+        svdb_vcfs=[
+            "cnv_sv/svdb_query/{sample}_{type}.svdb_query.annotate_cnv.cnv_amp_genes.vcf.gz",
+            "cnv_sv/svdb_query/{sample}_{type}.svdb_query.annotate_cnv.cnv_loh_genes.vcf.gz",
+        ],
+        svdb_tbis=[
+            "cnv_sv/svdb_query/{sample}_{type}.svdb_query.annotate_cnv.cnv_amp_genes.vcf.gz.tbi",
+            "cnv_sv/svdb_query/{sample}_{type}.svdb_query.annotate_cnv.cnv_loh_genes.vcf.gz.tbi",
+        ],
     output:
         json=temp("cnv_sv/cnv_html_report/{sample}_{type}.cnv.json"),
     params:

--- a/workflow/scripts/cnv_json.py
+++ b/workflow/scripts/cnv_json.py
@@ -23,24 +23,13 @@ def parse_cns(cnvkit_segments_filename):
             ) = line.strip().split()
             start = int(start)
             end = int(end)
-            genes = list(set(map(lambda x: x.split("_")[0], gene.strip().split(","))))
             log2 = float(log2)
-            depth = float(depth)
-            probes = int(probes)
-            weight = float(weight)
-            ci_lo = float(ci_lo)
-            ci_hi = float(ci_hi)
 
             cns_dict[chrom].append(
                 dict(
                     start=start,
                     end=end,
-                    genes=genes,
-                    depth=depth,
                     log2=log2,
-                    weight=weight,
-                    ci_lo=ci_lo,
-                    ci_hi=ci_hi,
                 )
             )
 
@@ -62,7 +51,6 @@ def parse_gatk_segments(gatk_segments_filename):
             ) = line.strip().split()
             start = int(start)
             end = int(end)
-            n_points = int(n_points)
             log2 = float(log2)
 
             segment_dict[chrom].append(
@@ -92,18 +80,13 @@ def parse_cnr(cnvkit_ratios_filename):
             chrom, start, end, gene, depth, log2, weight = line.strip().split()
             start = int(start)
             end = int(end)
-            depth = float(depth)
             log2 = float(log2)
-            weight = float(weight)
 
             cnr_dict[chrom].append(
                 dict(
-                    gene=gene,
                     start=start,
                     end=end,
-                    depth=depth,
                     log2=log2,
-                    weight=weight,
                 )
             )
 


### PR DESCRIPTION
This PR adds a results table to the CNV HTML report. It only shows results from the caller that has been selected on the top of the page. A user can visualise a certain region by clicking the magnifying glass on the corresponding row.

![image](https://user-images.githubusercontent.com/2573608/194562994-37172222-d9c2-487e-abe3-548abe5b08fa.png)
