### PR TITLE
fix: problem with empty CNV table

### DIFF
--- a/config/cnv_report_template.html
+++ b/config/cnv_report_template.html
@@ -799,6 +799,10 @@
                         }))
                     .flat();
 
+                if (tableData.length === 0) {
+                    tableData = [{"No data to display": []}];
+                }
+
                 tableHeader
                     .selectAll("th")
                     .data(Object.keys(tableData[0]), d => d)


### PR DESCRIPTION
The underlying data was there, but if one of the datasets was empty, it still tried to get the header information. Now we check if there is data available and set an appropriate message if not.