### PR TITLE
feat: only show filtered CNVs in the report

### DIFF
--- a/config/cnv_report_template.html
+++ b/config/cnv_report_template.html
@@ -294,6 +294,7 @@
                 </section>
             </div>
 
+            {% if metadata.show_table %}
             <div class="table-container">
                 <section>
                     <h2>Results table</h2>
@@ -306,6 +307,7 @@
                     </table>
                 </section>
             </div>
+            {% endif %}
         </div>
     </div>
     <script src="https://d3js.org/d3.v7.min.js"></script>
@@ -973,6 +975,9 @@
 
         const populateTable = () => {
             const table = d3.select("#cnv-table");
+            if (table.empty()) {
+                return null;
+            }
 
             const tableHeader = table.append("thead").append("tr");
             const tableBody = table.append("tbody");
@@ -1193,7 +1198,9 @@
             let [xMin, xMax] = chromosomeView.getZoomRange();
             chromosomeView.update(cnvData[genomeView.getSelectedChromosome()], xMin, xMax);
             genomeView.update();
-            resultsTable.update();
+            if (resultsTable) {
+                resultsTable.update();
+            }
         });
 
 

--- a/config/cnv_report_template.html
+++ b/config/cnv_report_template.html
@@ -1002,7 +1002,7 @@
                         return {
                             class: "right tooltip-trigger",
                             format: x => {
-                                if (x) {
+                                if (x !== null) {
                                     return x.toLocaleString(
                                         undefined,
                                         { minimumFractionDigits: 2 }

--- a/config/config.yaml
+++ b/config/config.yaml
@@ -97,7 +97,12 @@ cnvkit_export_seg:
   container: "docker://hydragenetics/cnvkit:0.9.9"
 
 cnv_html_report:
-  template: "config/cnv_report_template.html"
+  cnv_vcf:
+    - annotation: cnv_loh_genes
+      filter: cnv_hard_filter_loh
+    - annotation: cnv_amp_genes
+      filter: cnv_hard_filter_amp
+  template: config/cnv_report_template.html
 
 cnvkit_scatter:
   container: "docker://hydragenetics/cnvkit:0.9.9"

--- a/workflow/rules/cnv_html_report.smk
+++ b/workflow/rules/cnv_html_report.smk
@@ -70,6 +70,8 @@ rule cnv_html_report:
         template=config.get("cnv_html_report", {}).get("template", ""),
     output:
         html=temp("cnv_sv/cnv_html_report/{sample}_{type}.{tc_method}.cnv.html"),
+    params:
+        show_table=len(config.get("cnv_html_report", {}).get("cnv_vcf", [])) > 0,
     log:
         "cnv_sv/cnv_html_report/{sample}_{type}.{tc_method}.cnv.html.log",
     benchmark:

--- a/workflow/rules/cnv_html_report.smk
+++ b/workflow/rules/cnv_html_report.smk
@@ -28,32 +28,14 @@ rule cnv_json:
         "../scripts/cnv_json.py"
 
 
-def get_filtered_cnv_vcfs(wildcards):
-    cnv_vcfs = []
-    spec = config.get("cnv_html_report", {}).get("cnv_vcf", [])
-    for s in spec:
-        path = "cnv_sv/svdb_query/{{sample}}_{{type}}.svdb_query.annotate_cnv.{annotation}.filter.{filter}.vcf".format(**s)
-        cnv_vcfs.append(path)
-    return cnv_vcfs
-
-
-def get_cnv_vcfs(wildcards):
-    cnv_vcfs = []
-    spec = config.get("cnv_html_report", {}).get("cnv_vcf", [])
-    for s in spec:
-        path = "cnv_sv/svdb_query/{{sample}}_{{type}}.svdb_query.annotate_cnv.{annotation}.vcf".format(**s)
-        cnv_vcfs.append(path)
-    return cnv_vcfs
-
-
 rule merge_json:
     input:
         annotation_bed=list(config.get("annotate_cnv", {}).values()),
         fai=config.get("reference", {}).get("fai", ""),
         germline_vcf="snv_indels/bcbio_variation_recall_ensemble/{sample}_{type}.ensembled.vep_annotated.filter.germline.vcf",
         json=get_json_for_merge_json,
-        cnv_vcfs=get_cnv_vcfs,
-        filtered_cnv_vcfs=get_filtered_cnv_vcfs,
+        cnv_vcfs=get_unfiltered_cnv_vcfs_for_merge_json,
+        filtered_cnv_vcfs=get_filtered_cnv_vcfs_for_merge_json,
     output:
         json=temp("cnv_sv/cnv_html_report/{sample}_{type}.{tc_method}.merged.json"),
     params:

--- a/workflow/rules/cnv_html_report.smk
+++ b/workflow/rules/cnv_html_report.smk
@@ -28,13 +28,32 @@ rule cnv_json:
         "../scripts/cnv_json.py"
 
 
+def get_filtered_cnv_vcfs(wildcards):
+    cnv_vcfs = []
+    spec = config.get("cnv_html_report", {}).get("cnv_vcf", [])
+    for s in spec:
+        path = "cnv_sv/svdb_query/{{sample}}_{{type}}.svdb_query.annotate_cnv.{annotation}.filter.{filter}.vcf".format(**s)
+        cnv_vcfs.append(path)
+    return cnv_vcfs
+
+
+def get_cnv_vcfs(wildcards):
+    cnv_vcfs = []
+    spec = config.get("cnv_html_report", {}).get("cnv_vcf", [])
+    for s in spec:
+        path = "cnv_sv/svdb_query/{{sample}}_{{type}}.svdb_query.annotate_cnv.{annotation}.vcf".format(**s)
+        cnv_vcfs.append(path)
+    return cnv_vcfs
+
+
 rule merge_json:
     input:
         annotation_bed=list(config.get("annotate_cnv", {}).values()),
         fai=config.get("reference", {}).get("fai", ""),
         germline_vcf="snv_indels/bcbio_variation_recall_ensemble/{sample}_{type}.ensembled.vep_annotated.filter.germline.vcf",
         json=get_json_for_merge_json,
-        svdb_vcfs=get_vcfs_for_merge_json,
+        cnv_vcfs=get_cnv_vcfs,
+        filtered_cnv_vcfs=get_filtered_cnv_vcfs,
     output:
         json=temp("cnv_sv/cnv_html_report/{sample}_{type}.{tc_method}.merged.json"),
     params:

--- a/workflow/rules/cnv_html_report.smk
+++ b/workflow/rules/cnv_html_report.smk
@@ -32,7 +32,7 @@ rule merge_json:
     input:
         annotation_bed=list(config.get("annotate_cnv", {}).values()),
         fai=config.get("reference", {}).get("fai", ""),
-        germline_vcf="snv_indels/bcbio_variation_recall_ensemble/{sample}_{type}.ensembled.vep_annotated.filter.germline.vcf",
+        germline_vcf="snv_indels/bcbio_variation_recall_ensemble/{sample}_{type}.ensembled.vep_annotated.filter.germline.exclude.blacklist.vcf.gz",
         json=get_json_for_merge_json,
         cnv_vcfs=get_unfiltered_cnv_vcfs_for_merge_json,
         filtered_cnv_vcfs=get_filtered_cnv_vcfs_for_merge_json,

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -125,26 +125,22 @@ def get_json_for_merge_json(wildcards):
 def get_filtered_cnv_vcfs_for_merge_json(wildcards):
     cnv_vcfs = []
     tags = config.get("cnv_html_report", {}).get("cnv_vcf", [])
-    for v in config.get("svdb_merge", {}).get("tc_method", {}):
-        tc_method = v["name"]
-        for t in tags:
-            cnv_vcfs.append(
-                f"cnv_sv/svdb_query/{wildcards.sample}_{wildcards.type}.{wildcards.tc_method}.svdb_query."
-                f"annotate_cnv.{t['annotation']}.filter.{t['filter']}.vcf"
-            )
+    for t in tags:
+        cnv_vcfs.append(
+            f"cnv_sv/svdb_query/{wildcards.sample}_{wildcards.type}.{wildcards.tc_method}.svdb_query."
+            f"annotate_cnv.{t['annotation']}.filter.{t['filter']}.vcf"
+        )
     return sorted(cnv_vcfs)
 
 
 def get_unfiltered_cnv_vcfs_for_merge_json(wildcards):
     cnv_vcfs = []
     tags = config.get("cnv_html_report", {}).get("cnv_vcf", [])
-    for v in config.get("svdb_merge", {}).get("tc_method", {}):
-        tc_method = v["name"]
-        for t in tags:
-            cnv_vcfs.append(
-                f"cnv_sv/svdb_query/{wildcards.sample}_{wildcards.type}.{wildcards.tc_method}.svdb_query."
-                f"annotate_cnv.{t['annotation']}.vcf"
-            )
+    for t in tags:
+        cnv_vcfs.append(
+            f"cnv_sv/svdb_query/{wildcards.sample}_{wildcards.type}.{wildcards.tc_method}.svdb_query."
+            f"annotate_cnv.{t['annotation']}.vcf"
+        )
     return sorted(cnv_vcfs)
 
 

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -122,21 +122,30 @@ def get_json_for_merge_json(wildcards):
     return json_dict[wildcards.tc_method]
 
 
-def get_vcfs_for_merge_json(wildcards):
-    vcf_dict = {}
-    for v in config.get("svdb_merge", {}).get("tc_method"):
+def get_filtered_cnv_vcfs_for_merge_json(wildcards):
+    cnv_vcfs = []
+    tags = config.get("cnv_html_report", {}).get("cnv_vcf", [])
+    for v in config.get("svdb_merge", {}).get("tc_method", {}):
         tc_method = v["name"]
-        tags = list(config.get("annotate_cnv", {}).keys())
-        for tag in tags:
-            if tc_method in vcf_dict:
-                vcf_dict[tc_method].append(
-                    f"cnv_sv/svdb_query/{wildcards.sample}_{wildcards.type}.{tc_method}.svdb_query.annotate_cnv.{tag}.vcf"
-                )
-            else:
-                vcf_dict[tc_method] = [
-                    f"cnv_sv/svdb_query/{wildcards.sample}_{wildcards.type}.{tc_method}.svdb_query.annotate_cnv.{tag}.vcf"
-                ]
-    return vcf_dict[wildcards.tc_method]
+        for t in tags:
+            cnv_vcfs.append(
+                f"cnv_sv/svdb_query/{wildcards.sample}_{wildcards.type}.{wildcards.tc_method}.svdb_query."
+                f"annotate_cnv.{t['annotation']}.filter.{t['filter']}.vcf"
+            )
+    return sorted(cnv_vcfs)
+
+
+def get_unfiltered_cnv_vcfs_for_merge_json(wildcards):
+    cnv_vcfs = []
+    tags = config.get("cnv_html_report", {}).get("cnv_vcf", [])
+    for v in config.get("svdb_merge", {}).get("tc_method", {}):
+        tc_method = v["name"]
+        for t in tags:
+            cnv_vcfs.append(
+                f"cnv_sv/svdb_query/{wildcards.sample}_{wildcards.type}.{wildcards.tc_method}.svdb_query."
+                f"annotate_cnv.{t['annotation']}.vcf"
+            )
+    return sorted(cnv_vcfs)
 
 
 def generate_copy_code(workflow, output_json):

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -128,7 +128,7 @@ def get_filtered_cnv_vcfs_for_merge_json(wildcards):
     for t in tags:
         cnv_vcfs.append(
             f"cnv_sv/svdb_query/{wildcards.sample}_{wildcards.type}.{wildcards.tc_method}.svdb_query."
-            f"annotate_cnv.{t['annotation']}.filter.{t['filter']}.vcf"
+            f"annotate_cnv.{t['annotation']}.filter.{t['filter']}.vcf.gz"
         )
     return sorted(cnv_vcfs)
 
@@ -139,7 +139,7 @@ def get_unfiltered_cnv_vcfs_for_merge_json(wildcards):
     for t in tags:
         cnv_vcfs.append(
             f"cnv_sv/svdb_query/{wildcards.sample}_{wildcards.type}.{wildcards.tc_method}.svdb_query."
-            f"annotate_cnv.{t['annotation']}.vcf"
+            f"annotate_cnv.{t['annotation']}.vcf.gz"
         )
     return sorted(cnv_vcfs)
 

--- a/workflow/schemas/config.schema.yaml
+++ b/workflow/schemas/config.schema.yaml
@@ -83,9 +83,30 @@ properties:
   cnv_html_report:
     type: object
     properties:
+      cnv_vcf:
+        description: >
+          A list of pairs of annotations and filters that should be applied to the svdb output.
+          This will be used for populating the results table of the report. If this list is empty,
+          no results table will be generated.
+        type: array
+        items:
+          description: >
+            A pair of values corresponding to an annotation tag and a filter tag.
+          type: object
+          properties:
+            annotation:
+              description: Annotation to apply (from `annotate_cnv`)
+              type: string
+            filter:
+              description: Filter to apply (from `filter_vcf`)
+              type: string
+          required:
+            - annotation
+            - filter
       template:
         type: string
-        description: path to HTML report template
+        description: Path to HTML report template
+        format: uri
     required:
       - template
 

--- a/workflow/scripts/cnv_html_report.py
+++ b/workflow/scripts/cnv_html_report.py
@@ -7,7 +7,7 @@ def get_sample_name(filename):
     return pathlib.Path(filename).name.split(".")[0]
 
 
-def create_report(template_filename, json_filename):
+def create_report(template_filename, json_filename, show_table):
     with open(template_filename) as f:
         template = Template(source=f.read())
 
@@ -17,7 +17,11 @@ def create_report(template_filename, json_filename):
     return template.render(
         dict(
             json=json_string,
-            metadata=dict(date=time.strftime("%Y-%m-%d %H:%M", time.localtime()), sample=get_sample_name(json_filename)),
+            metadata=dict(
+                date=time.strftime("%Y-%m-%d %H:%M", time.localtime()),
+                sample=get_sample_name(json_filename),
+                show_table=show_table,
+            ),
         )
     )
 
@@ -27,7 +31,7 @@ def main():
     template_filename = snakemake.input.template
     html_filename = snakemake.output.html
 
-    report = create_report(template_filename, json_filename)
+    report = create_report(template_filename, json_filename, snakemake.params.show_table)
 
     with open(html_filename, "w") as f:
         f.write(report)

--- a/workflow/scripts/merge_json.py
+++ b/workflow/scripts/merge_json.py
@@ -1,6 +1,37 @@
 from collections import defaultdict
 import cyvcf2
+from dataclasses import dataclass
 import json
+
+
+@dataclass
+class CNV:
+
+    caller: str
+    chromosome: str
+    genes: list
+    start: int
+    length: int
+    type: str
+    copy_number: float
+
+    def end(self):
+        return self.start + self.length - 1
+
+    def overlaps(self, other):
+        return self.chromosome == other.chromosome and (
+            # overlaps in the beginning, or self contained in other
+            (self.start >= other.start and self.start <= other.end())
+            or
+            # overlaps at the end, or self contained in other
+            (self.end() >= other.start and self.end() <= other.end())
+            or
+            # other is contained in self
+            (other.start >= self.start and other.end() <= self.end())
+        )
+
+    def __hash__(self):
+        return hash(f"{self.caller}_{self.chromosome}:{self.start}-{self.end()}_{self.copy_number}")
 
 
 def parse_fai(filename, skip=None):
@@ -30,7 +61,7 @@ def get_vaf(vcf_filename, skip=None):
 
 
 def get_cnvs(vcf_filename, skip=None):
-    cnvs = defaultdict(list)
+    cnvs = defaultdict(lambda: defaultdict(list))
     vcf = cyvcf2.VCF(vcf_filename)
     for variant in vcf:
         if skip is not None and variant.CHROM in skip:
@@ -41,20 +72,20 @@ def get_cnvs(vcf_filename, skip=None):
         genes = variant.INFO.get("Genes")
         if genes is None:
             continue
-        cnvs[caller].append(
-            dict(
-                chromosome=variant.CHROM,
-                genes=sorted(genes.split(",")),
-                start=variant.POS,
-                length=variant.INFO.get("SVLEN"),
-                type=variant.INFO.get("SVTYPE"),
-                copy_number=variant.INFO.get("CORR_CN"),
-            )
+        cnv = CNV(
+            caller,
+            variant.CHROM,
+            sorted(genes.split(",")),
+            variant.POS,
+            variant.INFO.get("SVLEN"),
+            variant.INFO.get("SVTYPE"),
+            variant.INFO.get("CORR_CN"),
         )
+        cnvs[variant.CHROM][caller].append(cnv)
     return cnvs
 
 
-def merge_cnv_dicts(dicts, vaf, annotations, chromosomes, svdb_cnvs):
+def merge_cnv_dicts(dicts, vaf, annotations, chromosomes, filtered_cnvs, unfiltered_cnvs):
     callers = list(map(lambda x: x["caller"], dicts))
     caller_labels = dict(
         cnvkit="cnvkit",
@@ -89,18 +120,43 @@ def merge_cnv_dicts(dicts, vaf, annotations, chromosomes, svdb_cnvs):
             )
         )
 
-    for d in svdb_cnvs:
-        for caller, cnv_list in d.items():
-            for c in cnv_list:
-                cnvs[c["chromosome"]]["callers"][caller]["cnvs"].append(
-                    dict(
-                        genes=c["genes"],
-                        start=c["start"],
-                        length=c["length"],
-                        type=c["type"],
-                        cn=c["copy_number"],
-                    )
-                )
+    # Iterate over the unfiltered CNVs and pair them according to overlap.
+    for uf_cnvs, f_cnvs in zip(unfiltered_cnvs, filtered_cnvs):
+        for chrom, cnvdict in uf_cnvs.items():
+            callers = sorted(list(cnvdict.keys()))
+            first_caller = callers[0]
+            rest_callers = callers[1:]
+
+            added_cnvs = set()
+
+            print(chrom, first_caller, rest_callers)
+            # Use the first caller in the list as the reference. It shouldn't
+            # matter which one I start with.
+            for cnv1 in cnvdict[first_caller]:
+                keep = False
+
+                if cnv1 in f_cnvs[chrom][first_caller]:
+                    keep = True
+
+                cnv_set = [cnv1]
+                for caller2 in rest_callers:
+                    for cnv2 in cnvdict[caller2]:
+                        if cnv2 in f_cnvs[chrom][caller2]:
+                            keep = True
+
+                        if cnv1.overlaps(cnv2):
+                            cnv_set.append(cnv2)
+
+                if keep:
+                    # At least one of the variants in the set is part of the
+                    # filtered variants.
+                    for c in cnv_set:
+                        if c in added_cnvs:
+                            continue
+                        cnvs[c.chromosome]["callers"][c.caller]["cnvs"].append(
+                            dict(genes=c.genes, start=c.start, length=c.length, type=c.type, cn=c.copy_number)
+                        )
+                        added_cnvs.add(c)
 
     for d in dicts:
         for r in d["ratios"]:
@@ -131,6 +187,7 @@ def main():
     fasta_index_file = snakemake.input["fai"]
     germline_vcf = snakemake.input["germline_vcf"]
     json_files = snakemake.input["json"]
+    filtered_cnv_vcf_files = snakemake.input["filtered_cnv_vcfs"]
     cnv_vcf_files = snakemake.input["cnv_vcfs"]
 
     output_file = snakemake.output["json"]
@@ -148,14 +205,13 @@ def main():
     for filename in annotation_beds:
         annotations.append(parse_annotation_bed(filename, skip_chromosomes))
 
-    cnv_vcfs = []
-    for filename in cnv_vcf_files:
-        # Parse VCF file and get annotated, called CNVs. If there are none,
-        # create an empty list for each caller. In this case, no table will
-        # be presented in the final report.
-        cnv_vcfs.append(get_cnvs(filename, skip_chromosomes))
+    filtered_cnv_vcfs = []
+    unfiltered_cnv_vcfs = []
+    for f_vcf, uf_vcf in zip(filtered_cnv_vcf_files, cnv_vcf_files):
+        filtered_cnv_vcfs.append(get_cnvs(f_vcf, skip_chromosomes))
+        unfiltered_cnv_vcfs.append(get_cnvs(uf_vcf, skip_chromosomes))
 
-    cnvs = merge_cnv_dicts(cnv_dicts, vaf, annotations, fai, cnv_vcfs)
+    cnvs = merge_cnv_dicts(cnv_dicts, vaf, annotations, fai, filtered_cnv_vcfs, unfiltered_cnv_vcfs)
 
     with open(output_file, "w") as f:
         print(json.dumps(cnvs), file=f)

--- a/workflow/scripts/merge_json.py
+++ b/workflow/scripts/merge_json.py
@@ -129,28 +129,23 @@ def merge_cnv_dicts(dicts, vaf, annotations, chromosomes, filtered_cnvs, unfilte
 
             added_cnvs = set()
 
-            print(chrom, first_caller, rest_callers)
-            # Use the first caller in the list as the reference. It shouldn't
-            # matter which one I start with.
             for cnv1 in cnvdict[first_caller]:
                 keep = False
 
                 if cnv1 in f_cnvs[chrom][first_caller]:
                     keep = True
 
-                cnv_set = [cnv1]
+                cnv_group = [cnv1]
                 for caller2 in rest_callers:
                     for cnv2 in cnvdict[caller2]:
-                        if cnv2 in f_cnvs[chrom][caller2]:
-                            keep = True
-
                         if cnv1.overlaps(cnv2):
-                            cnv_set.append(cnv2)
+                            if cnv2 in f_cnvs[chrom][caller2]:
+                                keep = True
+
+                            cnv_group.append(cnv2)
 
                 if keep:
-                    # At least one of the variants in the set is part of the
-                    # filtered variants.
-                    for c in cnv_set:
+                    for c in cnv_group:
                         if c in added_cnvs:
                             continue
                         cnvs[c.chromosome]["callers"][c.caller]["cnvs"].append(


### PR DESCRIPTION
This PR modifies the results table in the HTML report to only show a filtered set of CNVs. The configuration works by defining what combinations of annotations and filters to use. For example, the configuration below would look for two VCF files, one annotated according to the `cnv_loh_genes` tag and filtered according to `cnv_hard_filter_loh`, and the other annotated with the `cnv_amp_genes` tag and filtered with `cnv_hard_filter_amp`.

```yaml
cnv_html_report:
  template: "config/cnv_report_template.html"
  cnv_vcf:
    - annotation: cnv_loh_genes
      filter: cnv_hard_filter_loh
    - annotation: cnv_amp_genes
      filter: cnv_hard_filter_amp
  template: config/cnv_report_template.html
```

If `cnv_vcf` doesn't exist, or is empty, the results table in the report will not be generated.

The bug where copy numbers of zero became NA in the table has also been fixed.