### PR TITLE
feat: y-axis zoom in chromosome plot

### DIFF
--- a/config/cnv_report_template.html
+++ b/config/cnv_report_template.html
@@ -132,6 +132,10 @@
             font-family: helvetica, arial, sans-serif;
         }
 
+        .data-range-warning {
+            color: orange;
+        }
+
         .copy-number-tooltip {
             display: block;
             position: absolute;
@@ -139,10 +143,6 @@
             background-color: white;
             border: 1px solid black;
             width: 20em;
-        }
-
-        .copy-number-tooltip.hidden {
-            display: none;
         }
 
         .copy-number-tooltip tbody tr:nth-child(2n) {
@@ -238,6 +238,10 @@
             stroke-width: 6;
         }
 
+        .hidden {
+            display: none !important;
+        }
+
         /* Print layout */
         @media print {
             header {
@@ -293,6 +297,7 @@
                     <div class="no-print">
                         <input type="checkbox" id="chromosome-fit-to-data">
                         <label for="chromosome-fit-to-data">Zoom to data extent</label>
+                        <i class="data-range-warning fa-solid fa-triangle-exclamation" title="There are data points outside the current range"></i>
                     </div>
                     <svg id="chromosome-view"></svg>
                 </section>
@@ -314,6 +319,7 @@
             {% endif %}
         </div>
     </div>
+    <script src="https://kit.fontawesome.com/0a9e116953.js" crossorigin="anonymous"></script>
     <script src="https://d3js.org/d3.v7.min.js"></script>
     <script>
         const cnvData = {{ json }}
@@ -674,26 +680,30 @@
                 xScale.domain([0, data.length]);
                 if (xMin && xMax) {
                     xScale.domain([Math.max(xMin, 0), Math.min(xMax, data.length)]);
+                    const yMin = data.callers[callerIndex].ratios
+                        .filter(d => d.start > xMin && d.start < xMax)
+                        .map(d => d.log2)
+                        .reduce((a, d) => d < a ? d : a);
+                    const yMax = data.callers[callerIndex].ratios
+                        .filter(d => d.start > xMin && d.start < xMax)
+                        .map(d => d.log2)
+                        .reduce((a, d) => d > a ? d : a);
                     if (fitToData) {
-                        const yMin = data.callers[callerIndex].ratios
-                            .filter(d => d.start > xMin && d.start < xMax)
-                            .map(d => d.log2)
-                            .reduce((a, d) => d < a ? d : a);
-                        const yMax = data.callers[callerIndex].ratios
-                            .filter(d => d.start > xMin && d.start < xMax)
-                            .map(d => d.log2)
-                            .reduce((a, d) => d > a ? d : a);
+                        d3.selectAll(".data-range-warning").classed("hidden", true);
                         const padding = (yMax - yMin) * 0.05;
                         yScale.domain([yMin - padding, yMax + padding]);
                     } else {
+                        d3.selectAll(".data-range-warning").classed("hidden", !(yMin < -2 || yMax > 2));
                         yScale.domain([-2, 2]);
                     }
                 } else {
+                    const [yMin, yMax] = d3.extent(data.callers[callerIndex].ratios, d => d.log2);
                     if (fitToData) {
-                        const [yMin, yMax] = d3.extent(data.callers[callerIndex].ratios, d => d.log2);
+                        d3.selectAll(".data-range-warning").classed("hidden", true);
                         const padding = (yMax - yMin) * 0.05;
                         yScale.domain([yMin - padding, yMax + padding]);
                     } else {
+                        d3.selectAll(".data-range-warning").classed("hidden", !(yMin < -2 || yMax > 2));
                         yScale.domain([-2, 2]);
                     }
                 }

--- a/config/cnv_report_template.html
+++ b/config/cnv_report_template.html
@@ -289,7 +289,11 @@
 
                 <section class="chromosome-view plot-section">
                     <h2>Chromosome view</h2>
-                    <p class="no-print">Click and drag to zoom. Click the plot to reset zoom.</p>
+                    <p class="no-print">Click and drag to zoom along x-axis. Click the plot to reset zoom.</p>
+                    <div class="no-print">
+                        <input type="checkbox" id="chromosome-fit-to-data">
+                        <label for="chromosome-fit-to-data">Zoom to data extent</label>
+                    </div>
                     <svg id="chromosome-view"></svg>
                 </section>
             </div>
@@ -355,7 +359,6 @@
                 .range([0, width-margin.left-margin.right]);
 
             const yScale = d3.scaleLinear()
-                .domain(d3.extent(data.callers[getActiveCaller()].ratios, d => d.log2))
                 .range([plotHeight, 0]);
 
             const yScaleVAF = d3.scaleLinear()
@@ -376,20 +379,20 @@
                 .attr("viewBox", [0, 0, width, height])
                 .attr("style", "max-width: 100%; height: auto; max-height: 500px; height: intrinsic;");
 
-            // Clip path for plot area
+            // Clip path for log ratios
             svg.append("clipPath")
-                .attr("id", "plot-area-clip")
+                .attr("id", "lr-area-clip")
                 .append("rect")
                 .attr("width", width - margin.left - margin.right)
-                .attr("height", height - margin.top - margin.bottom);
+                .attr("height", plotHeight);
 
             const plotArea = svg.append("g")
                 .attr("transform", `translate(${margin.left},${margin.top})`)
-                .attr("class", "plot-area")
-                .attr("clip-path", "url(#plot-area-clip)");
+                .attr("class", "plot-area");
 
             const lrArea = plotArea.append("g")
-                .attr("id", "lr-plot");
+                .attr("id", "lr-plot")
+                .attr("clip-path", "url(#lr-area-clip)");
             const vafArea = plotArea.append("g")
                 .attr("id", "vaf-plot")
                 .attr("transform", `translate(0, ${plotHeight + margin.between})`)
@@ -667,20 +670,32 @@
             const update = function(plotData, xMin, xMax) {
                 data = plotData;
                 const callerIndex = getActiveCaller();
+                const fitToData = d3.select("#chromosome-fit-to-data").node().checked;
                 xScale.domain([0, data.length]);
                 if (xMin && xMax) {
                     xScale.domain([Math.max(xMin, 0), Math.min(xMax, data.length)]);
-                    const yMin = data.callers[callerIndex].ratios
-                        .filter(d => d.start > xMin && d.start < xMax)
-                        .map(d => d.log2)
-                        .reduce((a, d) => d < a ? d : a);
-                    const yMax = data.callers[callerIndex].ratios
-                        .filter(d => d.start > xMin && d.start < xMax)
-                        .map(d => d.log2)
-                        .reduce((a, d) => d > a ? d : a);
-                    yScale.domain([yMin, yMax]);
+                    if (fitToData) {
+                        const yMin = data.callers[callerIndex].ratios
+                            .filter(d => d.start > xMin && d.start < xMax)
+                            .map(d => d.log2)
+                            .reduce((a, d) => d < a ? d : a);
+                        const yMax = data.callers[callerIndex].ratios
+                            .filter(d => d.start > xMin && d.start < xMax)
+                            .map(d => d.log2)
+                            .reduce((a, d) => d > a ? d : a);
+                        const padding = (yMax - yMin) * 0.05;
+                        yScale.domain([yMin - padding, yMax + padding]);
+                    } else {
+                        yScale.domain([-2, 2]);
+                    }
                 } else {
-                    yScale.domain(d3.extent(data.callers[callerIndex].ratios, d => d.log2));
+                    if (fitToData) {
+                        const [yMin, yMax] = d3.extent(data.callers[callerIndex].ratios, d => d.log2);
+                        const padding = (yMax - yMin) * 0.05;
+                        yScale.domain([yMin - padding, yMax + padding]);
+                    } else {
+                        yScale.domain([-2, 2]);
+                    }
                 }
                 svg.transition().select(".x-axis")
                     .duration(500)
@@ -700,7 +715,7 @@
                 return xScale.domain();
             };
 
-            update(data, getActiveCaller());
+            update(data);
 
             return {
                 update: update,
@@ -1220,6 +1235,11 @@
         const chromosomeView = plotChromosomeView(cnvData[0]);
         const genomeView = plotGenomeView();
         const resultsTable = populateTable();
+
+        d3.select("#chromosome-fit-to-data").on("change", e => {
+            let [xMin, xMax] = chromosomeView.getZoomRange();
+            chromosomeView.update(cnvData[genomeView.getSelectedChromosome()], xMin, xMax);
+        });
 
         d3.selectAll("input[name=dataset]").on("change", e => {
             let [xMin, xMax] = chromosomeView.getZoomRange();


### PR DESCRIPTION
This PR adds a simple toggle zoom for the y-axis of the log ratios in the chromosome plot. The default range with the checkbox unchecked is [-2, 2], and if there are data points outside this range, a warning is shown. If the checkbox is checked, the y-axis is scaled to the extent of the data.

![Zoom demo](https://user-images.githubusercontent.com/2573608/214840821-8a7902da-19bd-484b-90ba-37ac36e79bf6.gif)

