### PR TITLE
fix: empty table in CNV report not initialised correctly

### DIFF
--- a/config/cnv_report_template.html
+++ b/config/cnv_report_template.html
@@ -1138,23 +1138,23 @@
 
                 if (tableData.length === 0) {
                     tableData = [{"No data to display": []}];
-                }
-
-                // Find the corresponding copy numbers from the other caller(s)
-                for (cnv of tableData) {
-                    // Same chromosome
-                    let chromData = cnvData.filter(d => d.chromosome === cnv.chromosome);
-                    // ... different caller
-                    let callerData = chromData[0].callers.filter((_d, i) => i !== callerIndex)
-                    // ... same gene
-                    let otherCnvs = callerData.map(
-                        d => d.cnvs
-                            .filter(c => cnv.genes.filter(g => c.genes.includes(g)).length > 0)
-                            .map(c => {
-                                return {caller: d.name, type: c.type, cn: c.cn}
-                            })
-                    ).flat();
-                    cnv.others = otherCnvs;
+                } else {
+                    // Find the corresponding copy numbers from the other caller(s)
+                    for (cnv of tableData) {
+                        // Same chromosome
+                        let chromData = cnvData.filter(d => d.chromosome === cnv.chromosome);
+                        // ... different caller
+                        let callerData = chromData[0].callers.filter((_d, i) => i !== callerIndex)
+                        // ... same gene
+                        let otherCnvs = callerData.map(
+                            d => d.cnvs
+                                .filter(c => cnv.genes.filter(g => c.genes.includes(g)).length > 0)
+                                .map(c => {
+                                    return {caller: d.name, type: c.type, cn: c.cn}
+                                })
+                        ).flat();
+                        cnv.others = otherCnvs;
+                    }
                 }
 
                 tableHeader


### PR DESCRIPTION
This PR fixes an issue when there are no results to display in the table. Now a proper message is shown if the table is supposed to be empty.

![image](https://user-images.githubusercontent.com/2573608/217175774-dd78b64f-7852-4695-9292-2d05091f9277.png)

I know I tested this behaviour at some point before, but it must have become out of sync with all the other restructuring going on.