### PR TITLE
feat: add tumor cell content to report

### DIFF
--- a/config/cnv_report_template.html
+++ b/config/cnv_report_template.html
@@ -276,6 +276,7 @@
             <ul>
                 <li>Sample: {{ metadata.sample }}</li>
                 <li>Date: <time>{{ metadata.date }}</time></li>
+                <li>Tumor cell content: {{ metadata.tc }} ({{ metadata.tc_method }})</li>
             </ul>
         </header>
 

--- a/workflow/rules/cnv_html_report.smk
+++ b/workflow/rules/cnv_html_report.smk
@@ -72,6 +72,8 @@ rule cnv_html_report:
         html=temp("cnv_sv/cnv_html_report/{sample}_{type}.{tc_method}.cnv.html"),
     params:
         show_table=len(config.get("cnv_html_report", {}).get("cnv_vcf", [])) > 0,
+        tc=get_tc,
+        tc_method=lambda wildcards: wildcards.tc_method,
     log:
         "cnv_sv/cnv_html_report/{sample}_{type}.{tc_method}.cnv.html.log",
     benchmark:

--- a/workflow/rules/common.smk
+++ b/workflow/rules/common.smk
@@ -133,6 +133,19 @@ def get_filtered_cnv_vcfs_for_merge_json(wildcards):
     return sorted(cnv_vcfs)
 
 
+def get_tc(wildcards):
+    tc_method = wildcards.tc_method
+    if tc_method == "pathology":
+        return get_sample(samples, wildcards)["tumor_content"]
+    else:
+        tc_file = f"cnv_sv/{tc_method}_purity_file/{wildcards.sample}_{wildcards.type}.purity.txt"
+        if not os.path.exists(tc_file):
+            return -1
+        else:
+            with open(tc_file) as f:
+                return f.read()
+
+
 def get_unfiltered_cnv_vcfs_for_merge_json(wildcards):
     cnv_vcfs = []
     tags = config.get("cnv_html_report", {}).get("cnv_vcf", [])

--- a/workflow/scripts/cnv_html_report.py
+++ b/workflow/scripts/cnv_html_report.py
@@ -7,7 +7,7 @@ def get_sample_name(filename):
     return pathlib.Path(filename).name.split(".")[0]
 
 
-def create_report(template_filename, json_filename, show_table):
+def create_report(template_filename, json_filename, show_table, tc, tc_method):
     with open(template_filename) as f:
         template = Template(source=f.read())
 
@@ -21,6 +21,8 @@ def create_report(template_filename, json_filename, show_table):
                 date=time.strftime("%Y-%m-%d %H:%M", time.localtime()),
                 sample=get_sample_name(json_filename),
                 show_table=show_table,
+                tc=tc,
+                tc_method=tc_method,
             ),
         )
     )
@@ -31,7 +33,13 @@ def main():
     template_filename = snakemake.input.template
     html_filename = snakemake.output.html
 
-    report = create_report(template_filename, json_filename, snakemake.params.show_table)
+    report = create_report(
+        template_filename,
+        json_filename,
+        snakemake.params.show_table,
+        snakemake.params.tc,
+        snakemake.params.tc_method,
+    )
 
     with open(html_filename, "w") as f:
         f.write(report)


### PR DESCRIPTION
This PR adds the tumor cell content and the method used to obtain it to the CNV report. For this, I more or less copied the `get_tc` function from the cnv_sv module. When the report eventually is moved to the cnv_sv module, this function can be removed, together with a bunch of other things in `common.smk`.