### PR TITLE
feat: toggle filtering of CNV table

### DIFF
--- a/config/cnv_report_template.html
+++ b/config/cnv_report_template.html
@@ -319,6 +319,12 @@
                     <p>
                         BAF values outside the range 0&ndash;1 might indicate that the tumor cell content is underestimated.
                     </p>
+                    <p>
+                        Note that variants labelled as COPY_NORMAL can be present in the filtered table.
+                        This indicates that there is a variant covering the same gene that has been called by a different caller.
+                    </p>
+                    <input type="checkbox" id="table-filter-toggle" checked />
+                    <label for="table-filter-toggle" title="Apply predefined filters to the table">Filter table</label>
                     <table id="cnv-table">
 
                     </table>
@@ -1041,6 +1047,7 @@
 
             const tableHeader = table.append("thead").append("tr");
             const tableBody = table.append("tbody");
+            let applyFilter = d3.select("#table-filter-toggle").node().checked;
 
             let tableData = null;
 
@@ -1111,7 +1118,11 @@
                     baf: "BAF",
                 };
 
-                return columns[col];
+                if (columns[col]) {
+                    return columns[col];
+                }
+
+                return col;
             };
 
             const tooltip = d3.select(".container")
@@ -1155,9 +1166,11 @@
                 const callerIndex = getActiveCaller();
                 tableData = cnvData
                     .map(d => d.callers[callerIndex].cnvs
+                        .filter(di => !applyFilter || (applyFilter && di.passed_filter))
                         .map(di => {
                             const allCols = {view: "🔍", chromosome: d.chromosome, ...di};
-                            const {caller, ...cols} = allCols;
+                            // Don't display caller and filter status in table
+                            const {caller, passed_filter, ...cols} = allCols;
                             return cols;
                         }))
                     .flat();
@@ -1226,6 +1239,11 @@
                             .style("left", `${e.layerX - dims.width - 20}px`);
                     });
             }
+
+            d3.select("#table-filter-toggle").on("change", (event) => {
+                applyFilter = event.target.checked;
+                update();
+            });
 
             const getData = () => tableData;
 

--- a/config/cnv_report_template.html
+++ b/config/cnv_report_template.html
@@ -321,7 +321,7 @@
                     </p>
                     <p>
                         Note that variants labelled as COPY_NORMAL can be present in the filtered table.
-                        This indicates that there is a variant covering the same gene that has been called by a different caller.
+                        This indicates that there is a variant covering the same gene that has been called by a different caller or the variant has a VAF value < 0.3 or > 0.7 .
                     </p>
                     <input type="checkbox" id="table-filter-toggle" checked />
                     <label for="table-filter-toggle" title="Apply predefined filters to the table">Filter table</label>

--- a/workflow/scripts/merge_json.py
+++ b/workflow/scripts/merge_json.py
@@ -129,31 +129,44 @@ def merge_cnv_dicts(dicts, vaf, annotations, chromosomes, filtered_cnvs, unfilte
             first_caller = callers[0]
             rest_callers = callers[1:]
 
+            # Keep track of added CNVs on a chromosome to avoid duplicates
             added_cnvs = set()
 
             for cnv1 in cnvdict[first_caller]:
-                keep = False
+                pass_filter = False
 
                 if cnv1 in f_cnvs[chrom][first_caller]:
-                    keep = True
+                    # The CNV is part of the filtered set, so all overlapping
+                    # CNVs should pass the filter.
+                    pass_filter = True
 
                 cnv_group = [cnv1]
                 for caller2 in rest_callers:
                     for cnv2 in cnvdict[caller2]:
                         if cnv1.overlaps(cnv2):
-                            if cnv2 in f_cnvs[chrom][caller2]:
-                                keep = True
-
+                            # Add overlapping CNVs from other callers
                             cnv_group.append(cnv2)
 
-                if keep:
-                    for c in cnv_group:
-                        if c in added_cnvs:
-                            continue
-                        cnvs[c.chromosome]["callers"][c.caller]["cnvs"].append(
-                            dict(genes=c.genes, start=c.start, length=c.length, type=c.type, cn=c.copy_number, baf=c.baf)
+                            if cnv2 in f_cnvs[chrom][caller2]:
+                                # If the overlapping CNV is part of the filtered
+                                # set, the whole group should pass the filter.
+                                pass_filter = True
+
+                for c in cnv_group:
+                    if c in added_cnvs:
+                        continue
+                    cnvs[c.chromosome]["callers"][c.caller]["cnvs"].append(
+                        dict(
+                            genes=c.genes,
+                            start=c.start,
+                            length=c.length,
+                            type=c.type,
+                            cn=c.copy_number,
+                            baf=c.baf,
+                            passed_filter=pass_filter,
                         )
-                        added_cnvs.add(c)
+                    )
+                    added_cnvs.add(c)
 
     for d in dicts:
         for r in d["ratios"]:


### PR DESCRIPTION
This PR adds a checkbox to the CNV HTML report that toggles filtering of the variants. The filter is enabled by default. When applying the filter, COPY_NORMAL variants might still show up in the table, and the reason for this is that a variant from another caller covering the same gene passed the filter. A note explaining this has also been added.

![Screenshot of a few rows of the CNV table with filtering enabled](https://user-images.githubusercontent.com/2573608/223104532-398fbb21-dd0c-4b13-8642-57474df271a3.png)
