### PR TITLE
feat: drop low coverage

### DIFF
--- a/config/config.yaml
+++ b/config/config.yaml
@@ -86,6 +86,7 @@ call_small_cnv_deletions:
 
 cnvkit_batch:
   container: "docker://hydragenetics/cnvkit:0.9.9"
+  extra: "--drop-low-coverage"
   normal_reference: "/projects/wp1/nobackup/ngs/utveckling/Twist_DNA_DATA/PoN/cnvkit_nextseq_36.cnn"
   method: "hybrid"
 


### PR DESCRIPTION
When cnvkit finds regions with really low coverage in tumors, this is almost always due to sequencing errors or probe failure.  The option --drop-low-coverage removes regions with under -15 in log2ratio. This will solve the outliers that sometimes appear in our plots. https://cnvkit.readthedocs.io/en/stable/tumor.html

### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests:
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
