### PR TITLE
fix: correct paths for CNV report extra tables

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -633,7 +633,7 @@ use rule cnv_html_report from reports as reports_cnv_html_report with:
         js_files=workflow.get_rule("reports_cnv_html_report").input.js_files,
         css_files=workflow.get_rule("reports_cnv_html_report").input.css_files,
         tc_file=get_tc_file,
-        extra_table_files=config.get("cnv_html_report", {}).get("extra_table_files", []),
+        extra_table_files=[t["path"] for t in config.get("cnv_html_report", {}).get("extra_tables", [])],
     params:
         include_table=config.get("cnv_html_report", {}).get("show_table", True),
         include_cytobands=config.get("cnv_html_report", {}).get("show_cytobands", True),


### PR DESCRIPTION
This error was at first not apparent since whether or not it manifested itself depended on how the rule graph was resolved. Now the report should never be generated before all required files are available.