### PR TITLE
fix: jumble output is dependent on design bed name

### DIFF
--- a/config/output_reference_files.yaml
+++ b/config/output_reference_files.yaml
@@ -5,7 +5,7 @@ files:
     types:
       - N
   - name: jumble_pon
-    input: references/jumble_reference/design.bed.reference.RDS
+    input: references/jumble_reference/pool1_pool2.sort.merged.padded20.cnv200.hg19.split_fusion_genes.reannotated.230222.bed.reference.RDS
     output: result/jumble.PoN.RDS
     types:
       - N

--- a/config/output_reference_files.yaml
+++ b/config/output_reference_files.yaml
@@ -5,7 +5,7 @@ files:
     types:
       - N
   - name: jumble_pon
-    input: references/jumble_reference/pool1_pool2.sort.merged.padded20.cnv200.hg19.split_fusion_genes.reannotated.230222.bed.reference.RDS
+    input: references/jumble_reference/{design}.reference.RDS
     output: result/jumble.PoN.RDS
     types:
       - N

--- a/config/output_reference_files.yaml
+++ b/config/output_reference_files.yaml
@@ -6,7 +6,7 @@ files:
       - N
   - name: jumble_pon
     input: references/jumble_reference/{design}.reference.RDS
-    output: result/jumble.PoN.RDS
+    output: result/jumble.{design}.PoN.RDS
     types:
       - N
   - name: gatk_pon

--- a/workflow/rules/common_references.smk
+++ b/workflow/rules/common_references.smk
@@ -54,11 +54,12 @@ def compile_output_list(wildcards):
     for filedef in output_spec["files"]:
         output_files += set(
             [
-                filedef["output"].format(sample=sample, type=unit_type, caller=caller)
+                filedef["output"].format(sample=sample, type=unit_type, caller=caller, design=design)
                 for sample in get_samples(samples)
                 for unit_type in get_unit_types(units, sample)
                 if unit_type in set(filedef["types"]).intersection(types)
                 for caller in config["bcbio_variation_recall_ensemble"]["callers"]
+                for design in config["reference"]["design_bed"]
             ]
         )
     return list(set(output_files))

--- a/workflow/rules/common_references.smk
+++ b/workflow/rules/common_references.smk
@@ -54,7 +54,9 @@ def compile_output_list(wildcards):
     for filedef in output_spec["files"]:
         output_files += set(
             [
-                filedef["output"].format(sample=sample, type=unit_type, caller=caller, design=config["reference"]["design_bed"].split("/")[-1])
+                filedef["output"].format(
+                    sample=sample, type=unit_type, caller=caller, design=config["reference"]["design_bed"].split("/")[-1]
+                )
                 for sample in get_samples(samples)
                 for unit_type in get_unit_types(units, sample)
                 if unit_type in set(filedef["types"]).intersection(types)

--- a/workflow/rules/common_references.smk
+++ b/workflow/rules/common_references.smk
@@ -59,7 +59,7 @@ def compile_output_list(wildcards):
                 for unit_type in get_unit_types(units, sample)
                 if unit_type in set(filedef["types"]).intersection(types)
                 for caller in config["bcbio_variation_recall_ensemble"]["callers"]
-                for design in config["reference"]["design_bed"]
+                for design in config["reference"]["design_bed"].split("/")[-1]
             ]
         )
     return list(set(output_files))

--- a/workflow/rules/common_references.smk
+++ b/workflow/rules/common_references.smk
@@ -54,12 +54,11 @@ def compile_output_list(wildcards):
     for filedef in output_spec["files"]:
         output_files += set(
             [
-                filedef["output"].format(sample=sample, type=unit_type, caller=caller, design=design)
+                filedef["output"].format(sample=sample, type=unit_type, caller=caller, design=config["reference"]["design_bed"].split("/")[-1])
                 for sample in get_samples(samples)
                 for unit_type in get_unit_types(units, sample)
                 if unit_type in set(filedef["types"]).intersection(types)
                 for caller in config["bcbio_variation_recall_ensemble"]["callers"]
-                for design in config["reference"]["design_bed"].split("/")[-1]
             ]
         )
     return list(set(output_files))


### PR DESCRIPTION
The output from Jumble_reference is dependent on the design file used. This fixes so that the output file name is collected from the config file used and not have to be hardcoded and changed when the design bed is updated. 
It also fixes the integration tests which has a different name of design bed file.