### PR TITLE
feat: Handling complex variants in snv_indel

### DIFF
--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -190,7 +190,7 @@ use rule samtools_merge_bam from alignment as alignment_samtools_merge_bam_mutec
 
 module snv_indels:
     snakefile:
-        get_module_snakefile(config, "hydra-genetics/snv_indels", path="workflow/Snakefile", tag="v0.3.0")
+        get_module_snakefile(config, "hydra-genetics/snv_indels", path="workflow/Snakefile", tag="v1.1.0")
     config:
         config
 

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -245,6 +245,7 @@ use rule * from annotation exclude all as annotation_*
 use rule bgzip_vcf from annotation as annotation_bgzip_vcf with:
     wildcard_constraints:
         file="^qc/.+",
+        
 
 use rule tabix_vcf from annotation as annotation_tabix_vcf with:
     wildcard_constraints:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -305,7 +305,7 @@ use rule * from filtering exclude all as filtering_*
 
 use rule filter_vcf from filtering as filtering_filter_vcf with:
     wildcard_constraints:
-        file="^cnv_sv/.+|^snv_indels/.+"
+        file="^cnv_sv/.+|^snv_indels/.+",
 
 
 module qc:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -245,11 +245,16 @@ use rule * from annotation exclude all as annotation_*
 use rule bgzip_vcf from annotation as annotation_bgzip_vcf with:
     wildcard_constraints:
         file="^qc/.+",
-        
+
 
 use rule tabix_vcf from annotation as annotation_tabix_vcf with:
     wildcard_constraints:
         file="^qc/.+",
+
+
+use rule annotate_cnv from annotation as annotation_annotate_cnv with:
+    wildcard_constraints:
+        file="^cnv_sv/.+",
 
 
 use rule vep from annotation as annotation_vep_wo_pick with:

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -303,6 +303,11 @@ module filtering:
 use rule * from filtering exclude all as filtering_*
 
 
+use rule filter_vcf from filtering as filtering_filter_vcf with:
+    wildcard_constraints:
+        file="^cnv_sv/.+|^snv_indels/.+"
+
+
 module qc:
     snakefile:
         get_module_snakefile(config, "hydra-genetics/qc", path="workflow/Snakefile", tag="v0.5.0")

--- a/workflow/Snakefile
+++ b/workflow/Snakefile
@@ -239,7 +239,16 @@ module annotation:
         config
 
 
-use rule * from annotation exclude all, bgzip_vcf, tabix_vcf as annotation_*
+use rule * from annotation exclude all as annotation_*
+
+
+use rule bgzip_vcf from annotation as annotation_bgzip_vcf with:
+    wildcard_constraints:
+        file="^qc/.+",
+
+use rule tabix_vcf from annotation as annotation_tabix_vcf with:
+    wildcard_constraints:
+        file="^qc/.+",
 
 
 use rule vep from annotation as annotation_vep_wo_pick with:

--- a/workflow/Snakefile_references.smk
+++ b/workflow/Snakefile_references.smk
@@ -70,6 +70,16 @@ module misc:
         config
 
 
+use rule tabix from misc as misc_tabix with:
+    wildcard_constraints:
+        file="^references/.+",
+
+
+use rule bgzip from misc as misc_bgzip with:
+    wildcard_constraints:
+        file="^references/.+",
+
+
 module references:
     snakefile:
         github("hydra-genetics/references", path="workflow/Snakefile", tag="781a186")


### PR DESCRIPTION
### This PR:

New version of module snv_indels.

Added: Python script for handling complex variants with several vcf records.

Some variant callers (e.g. vardict) will compose variants within close physical distance and report it as one complex variant. vt_decompose will separate these complex variants into separate records. However, during decomposition the same allele might be reported in several records, one originating from the single variant and one or more records reported from one or more complex variants, even if these records are corresponding to the same allele at the same position. The allele frequencies will also be different for these records since it might be derived from the frequency of the allele in combination with a specific allele at another position whithin the complex variant.

This python script can turn several records from the same allele at the same position into one record. Depending on the method given by the user the allele frequency and metrics derived from this will be reported differently. "skip" is the default method and in this case no alterations of the records will be made. All records for a complex variant will be returned in the output vcf. The method "max" will return the record with the highest allele frequency and discard any additional records, with the same allele and position, from the output vcf. The "sum" method will sum the allele frequencies from all records with the same allele and position.

