### PR TITLE
fix(jumble): NA-handling set to True for missing BAF values

### DIFF
--- a/config/filters/config_hard_filter_cnv_loh.yaml
+++ b/config/filters/config_hard_filter_cnv_loh.yaml
@@ -5,7 +5,7 @@ filters:
     soft_filter: "False"
   copy_number:
     description: "Hard filter cnvs with over 1.4 copies if the BAF is close to 0.5 as well as all amplifications"
-    expression: "(INFO:CORR_CN > 1.4 and INFO:BAF > 0.3 and INFO:BAF < 0.7) or (INFO:CORR_CN > 2.5)"
+    expression: "(INFO:CORR_CN > 1.4 and INFO:NA_TRUE:BAF > 0.3 and INFO:NA_TRUE:BAF < 0.7) or (INFO:CORR_CN > 2.5)"
     soft_filter: "False"
   loh_gene:
     description: "Only keep variants with gene annotations"


### PR DESCRIPTION
Jumble does not report BAF-values. So when we filter on BAF-values the CNV calls will not be filtered due to NA-handling returns false by default. The NA-handling is now set to True for the BAF-values to fix this.

### This PR:

(If this is a release PR, no need to add following. Leave this part empty)
(Use the following lines to create a PR text body. Make sure to remove all non-relevant one after you're done)
(Repeat each field as many times as necessary)

Added: for new features.
Changed: for changes in existing functionality.
Deprecated: for soon-to-be removed features.
Removed: for now removed features.
Fixed: for any bug fixes.
Security: in case of vulnerabilities.

### Review and tests:
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
