### PR TITLE
fix: update additional figshare links

### DIFF
--- a/config/references/design_files.hg19.yaml
+++ b/config/references/design_files.hg19.yaml
@@ -233,7 +233,7 @@
      checksum: b3dbb69ea4adeed19c01de0896295fa3
      path: GMS560/design/gatk.preprocessed.cfDNA_nextseq2000_24.interval_list
      type: file
-     url: https://figshare.scilifelab.se/ndownloader/files/52731446
+     url: https://figshare.scilifelab.se/ndownloader/files/52731446?private_link=88202740beb6fcbac09d
   
    design_intervals_rna:
      checksum: 5e38c3495625d3f854859eddf1643ff7
@@ -260,24 +260,24 @@
       checksum: 46ebd877c3eee497feaa2394a6d9576e
       path: GMS560/annotation/ENCODE_problematic_regions.bed
       type: file
-      url: https://figshare.scilifelab.se/ndownloader/files/52836086
+      url: https://figshare.scilifelab.se/ndownloader/files/52836086?private_link=88202740beb6fcbac09d
    bed_file2:
       checksum: 0e85c1e639e6ca0083fbe9348af645ce
       path: GMS560/annotation/segmental_dup_regions.bed
       type: file
-      url: https://figshare.scilifelab.se/ndownloader/files/52836089
+      url: https://figshare.scilifelab.se/ndownloader/files/52836089?private_link=88202740beb6fcbac09d
    bed_file3:
       checksum: c18f59ea5f30170a4cc6ad13a8251327
       path: GMS560/annotation/self_aligned_regions.bed
       type: file
-      url: https://figshare.scilifelab.se/ndownloader/files/52836095
+      url: https://figshare.scilifelab.se/ndownloader/files/52836095?private_link=88202740beb6fcbac09d
    bed_file4:
       checksum: 2dc84d77ab58b16fd429fea271cc2d75
       path: GMS560/annotation/simple_repeat_regions.bed
       type: file
-      url: https://figshare.scilifelab.se/ndownloader/files/52836092
+      url: https://figshare.scilifelab.se/ndownloader/files/52836092?private_link=88202740beb6fcbac09d
    bed_file5:
       checksum: d150be91d8cb15199a04cf99edfbf3f5
       path: GMS560/annotation/windowmaskSdust_repetetive_regions.bed
       type: file
-      url: https://figshare.scilifelab.se/ndownloader/files/52836098
+      url: https://figshare.scilifelab.se/ndownloader/files/52836098?private_link=88202740beb6fcbac09d


### PR DESCRIPTION
### This PR:


Fixed: Updating figshare links for ctDNA reference files.


### Review and tests:
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
