### PR TITLE
fix(multiqc_config_rna.yaml): Allow lower case

### DIFF
--- a/config/reports/multiqc_config_rna.yaml
+++ b/config/reports/multiqc_config_rna.yaml
@@ -15,7 +15,7 @@ extra_fn_clean_exts: ##from this until end
     - '.HsMetrics'
     - '.alignment_summary_metrics'
     - type: regex_keep
-      pattern: '[0-9A-Z-]+'
+      pattern: '[0-9A-Za-z-]+'
 #extra_fn_clean_trim:   #if found in beginning or end
 #fn_ignore_dirs:
 #fn_ignore_files:


### PR DESCRIPTION
### This PR:

MultiQC configuration updated: Allow lower case letters in RNA sample names.
