### PR TITLE
fix: adjust GRCh37 VEP cache download location

### DIFF
--- a/config/references/references.hg19.yaml
+++ b/config/references/references.hg19.yaml
@@ -411,7 +411,7 @@
   vep:
     vep_cache:
       compressed_checksum: 6eb952ad8c1003b7e1a9b011771fae9e
-      path: ref_data/vep/105/homo_sapiens_refseq
+      path: ref_data/vep/105
       type: folder
       content_checksum:
         homo_sapiens_refseq/105_GRCh37/HG1463_PATCH/114000001-115000000_reg.gz: c01d9c84f552841842da29450cbe3e9f


### PR DESCRIPTION
### This PR:

The VEP cache for GRCh37 ended up one level too deep (`ref_data/vep/105/homo_sapiens_refseq/homo_sapiens_refseq` instead of `ref_data/vep/105/homo_sapiens_refseq`). At least when having caches for both GRCh38 and GRCh37, VEP then only detected the GRCh38 cache with the previous configuration. With this change I was able to have both versions co-existing without any apparent issues.

### Review and tests:
- [ ] Tests pass
- [ ] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [ ] New code is executed and covered by tests, and test approve
