### PR TITLE
fix: handle AF segments without variance

### DIFF
--- a/workflow/scripts/estimate_ctDNA_fraction.py
+++ b/workflow/scripts/estimate_ctDNA_fraction.py
@@ -219,6 +219,10 @@ def test_if_signal_in_segment(segment, abs_value_seg_median, median_noise_level,
                                                                germline SNPs on both sides of the VAF baseline)
         * both the minimum maximum ratio (min / max1 and min / max2) is lower than 0.85
     '''
+    # KDE cannot estimate a density for segments without variance
+    if len(set(segment)) < 2:
+        return False
+
     # Get VAF for max density on the lower AF half of the BAF plot
     kde1 = stats.gaussian_kde(segment)
     kde1.set_bandwidth(bw_method=kde1.factor / 2.)

--- a/workflow/scripts/estimate_ctDNA_fraction_test.py
+++ b/workflow/scripts/estimate_ctDNA_fraction_test.py
@@ -49,6 +49,7 @@ test_segment = [0.6001999735832214, 0.3828999936580658, 0.690200012922287, 0.347
                 0.37929999232292175, 0.634500002861023, 0.6522000193595886, 0.3812999963760376, 0.3706000089645386,
                 0.6550000071525574, 0.3221000075340271, 0.3345000088214874, 0.3458000063896179]
 
+test_segment_no_variance = [0.1445000022649765] * 59
 
 test_segment_dict4 = {
     'chr2': [[138974, 242801052, 1.9299999475479126,
@@ -146,6 +147,17 @@ class TestUnitUtils(unittest.TestCase):
         signal_bool = test_if_signal_in_segment(test_segment, 1, 0, self.vaf_baseline)
 
         test_signal_bool = True
+
+        try:
+            self.assertEqual(test_signal_bool, signal_bool)
+        except AssertionError as e:
+            print(f"Failed testing signal in segment. {test_signal_bool} {signal_bool}")
+            raise e
+
+        # Test no signal in segment when all values are the same
+        signal_bool = test_if_signal_in_segment(test_segment_no_variance, 1, 0, self.vaf_baseline)
+
+        test_signal_bool = False
 
         try:
             self.assertEqual(test_signal_bool, signal_bool)


### PR DESCRIPTION
### This PR:

Fixed: `test_if_signal_in_segment()` for segments with no variance.

Previously, `stats.gaussian_kde()` could crash when all values in `segment` were identical. The function now returns `False` early for such segments, since identical values do not contain the two-peak BAF pattern required for signal detection.

No linked issue. This fixes a small crash found while running routine samples.

### Review and tests:
- [X] Tests pass
  - `python -m pytest workflow/scripts/*_test.py`
  - `python -m pytest .tests/units/`
- [X] If you've fixed a bug or added code that should be tested, add tests!
- [ ] Code review
- [ ] `CHANGELOG.md` is updated
- [X] New code is executed and covered by tests, and test approve
